### PR TITLE
Bug Fix: No stack trace for Control-c

### DIFF
--- a/letters.py
+++ b/letters.py
@@ -102,4 +102,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
It's possible to break this by using Control-c when the program isn't accepting input - this prevents that and will end gracefully. 
